### PR TITLE
Portal properties cleanup

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,10 +1,10 @@
 Changelog
 =========
 
-2.0.9 (unreleased)
+2.1.0 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Pull lock_on_ttw_edit setting from 
 
 
 2.0.8 (2015-07-20)

--- a/plone/locking/lockable.py
+++ b/plone/locking/lockable.py
@@ -4,9 +4,9 @@ from zope.component import adapts, queryAdapter
 from persistent.dict import PersistentDict
 
 from zope.annotation.interfaces import IAnnotations
+from zope.component import getUtility
 
 from AccessControl import getSecurityManager
-from Products.CMFCore.utils import getToolByName
 from webdav.LockItem import LockItem
 
 from plone.locking.interfaces import IRefreshableLockable
@@ -39,10 +39,9 @@ class TTWLockable(object):
     def lock(self, lock_type=STEALABLE_LOCK, children=False):
         settings = queryAdapter(self.context, ILockSettings)
         if settings is None:
-            # No context specific adapter, is this a Plone site?
-            pprops = getToolByName(self.context, 'portal_properties', None)
-            if pprops is not None and 'site_properties' in pprops.objectIds():
-                settings = pprops.site_properties
+            registry = getUtility(IRegistry)
+            settings = registry.forInterface(ISiteSchema,
+                                             prefix='plone')
         if settings is not None and settings.lock_on_ttw_edit is False:
             return
 

--- a/plone/locking/lockable.py
+++ b/plone/locking/lockable.py
@@ -9,6 +9,9 @@ from zope.component import getUtility
 from AccessControl import getSecurityManager
 from webdav.LockItem import LockItem
 
+from plone.registry.interfaces import IRegistry
+from Products.CMFPlone.interfaces import ISiteSchema
+
 from plone.locking.interfaces import IRefreshableLockable
 from plone.locking.interfaces import INonStealableLock
 from plone.locking.interfaces import ITTWLockable

--- a/plone/locking/lockable.py
+++ b/plone/locking/lockable.py
@@ -10,7 +10,7 @@ from AccessControl import getSecurityManager
 from webdav.LockItem import LockItem
 
 from plone.registry.interfaces import IRegistry
-from Products.CMFPlone.interfaces import ISiteSchema
+from Products.CMFPlone.interfaces import IEditingSchema
 
 from plone.locking.interfaces import IRefreshableLockable
 from plone.locking.interfaces import INonStealableLock
@@ -43,7 +43,7 @@ class TTWLockable(object):
         settings = queryAdapter(self.context, ILockSettings)
         if settings is None:
             registry = getUtility(IRegistry)
-            settings = registry.forInterface(ISiteSchema,
+            settings = registry.forInterface(IEditingSchema,
                                              prefix='plone')
         if settings is not None and settings.lock_on_ttw_edit is False:
             return

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 from setuptools import setup, find_packages
 
-version = '2.0.9.dev0'
+version = '2.1.0.dev0'
 
 setup(name='plone.locking',
       version=version,


### PR DESCRIPTION
Pull lock_on_ttw_edit from the configuration registry instead of portal_properties. Refs plone/Products.CMFPlone#345