### PR TITLE
Locks stored as annotations are safe to write

### DIFF
--- a/plone/locking/lockable.py
+++ b/plone/locking/lockable.py
@@ -58,6 +58,7 @@ class TTWLockable(object):
 
             locks = self._locks()
             locks[lock_type.__name__] = dict(type=lock_type, token=token)
+            safeWrite(locks)
             safeWrite(self.context)
 
     def refresh_lock(self, lock_type=STEALABLE_LOCK):


### PR DESCRIPTION
plone.protect safeWrite looks for the oid of the object passed.

self.context has one oid and the locks variable which ends up as an annotation on self.context has a different oid, thus causing a not protected write on read.

@vangheem I spend like two or three days staring at the code until the [excellent blog post](http://devblog.4teamwork.ch/blog/2015/10/12/debugging-csrf-protection-false-positives-in-plone/) from @lukasgraf saved my day.

Does this look fine? I'm seeing that at every request this ``lock`` method is called twice and the first time ``locks`` does not have a ``_p_oid`` so a warning by ``safeWrite`` will be generated...

Last thing, sorry for dumping my notes here, I see that on the [previous commit](https://github.com/plone/plone.locking/commit/e23cd15326a87cd224b7d62a0efd781246ab6cb2) that fixed the CSRF issues in this ``lock`` method self.context is both ``self.context._v_safe_write = True`` and ``safeWrite(self.context)`` I didn't dig further but given the semantics seems that they are doing the same somehow (making self.context safe for writing).