### PR TITLE
Backport #9 for Plone 4.3

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,8 +4,8 @@ Changelog
 2.0.9 (unreleased)
 ------------------
 
-- Nothing changed yet.
-
+- Locks stored on annotations are a safe write on read.
+  [gforcada]
 
 2.0.8 (2015-07-20)
 ------------------

--- a/plone/locking/lockable.py
+++ b/plone/locking/lockable.py
@@ -56,6 +56,8 @@ class TTWLockable(object):
 
             locks = self._locks()
             locks[lock_type.__name__] = dict(type=lock_type, token=token)
+            if getattr(locks, '_p_oid', None) is not None:
+                safeWrite(locks)
             safeWrite(self.context)
 
     def refresh_lock(self, lock_type=STEALABLE_LOCK):


### PR DESCRIPTION
As plone.locking is targetting only Plone 5 this pull request brings the fix done on #9 for Plone 4.3