### PR TITLE
Update README.rst with Compatibility

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,7 +10,8 @@ Breaking changes:
 
 New features:
 
-- *add item here*
+- Update README.rst with Compatibility
+  [djowett]
 
 Bug fixes:
 

--- a/README.rst
+++ b/README.rst
@@ -5,3 +5,12 @@ Provides basic automatic locking support for Plone. Locks are stealable by
 default, meaning that a user with edit privileges will be able to steal
 another user's lock, but will be warned that someone else may be editing
 the same object. Used by Plone, Archetypes and plone.app.iterate
+
+Compatibility
+-------------
+
+The versions 2.1.x (built from the master-branch) are used in Plone 5 and are not compatible with earlier Plone versions.
+
+Versions 2.0.x are used by Plone 4.x (but *may* also be compatible with earlier versions).
+
+Versions 1.x are used by Plone 3.


### PR DESCRIPTION
In particular to note that 2.1.x requires Plone 5.

What uses version 1.x was figured out from http://dist.plone.org/release/