### PR TITLE
All LockingOperations method can optionally redirect to the context view

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,7 +1,7 @@
 Changelog
 =========
 
-2.1.4 (unreleased)
+2.2.0 (unreleased)
 ------------------
 
 Breaking changes:
@@ -10,7 +10,8 @@ Breaking changes:
 
 New features:
 
-- *add item here*
+- All LockingOperations method can optionally redirect to the context view
+  [ale-rt]
 
 Bug fixes:
 

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 from setuptools import setup, find_packages
 
-version = '2.1.4.dev0'
+version = '2.2.0.dev0'
 
 setup(name='plone.locking',
       version=version,


### PR DESCRIPTION
The method `force_unlock` was smart enough to accept a boolean `redirect` parameter.
I extended the same behavior to the other methods and factored out the redirect code in to a reusable method.