### PR TITLE
Add fallback plone_lock_info view 

### DIFF
--- a/news/3331.fix
+++ b/news/3331.fix
@@ -1,0 +1,2 @@
+Register a fallback @@plone_lock_info view to allow objects without plone.locking behavior to be edited.
+[ericof]

--- a/plone/locking/browser/locking.py
+++ b/plone/locking/browser/locking.py
@@ -161,3 +161,23 @@ class LockingInformation(BrowserView):
             else:
                 dateString = _(u"$d days and $h hours", mapping={'d': days, 'h': hours})
         return dateString
+
+
+class LockingInformationFallback(BrowserView):
+    """Fallback view for Lock information.
+
+    This view exists to return sensible defaults if a content type does
+    not have the plone.locking behavior active.
+    """
+
+    def is_locked(self):
+        return False
+
+    def is_locked_for_current_user(self):
+        return False
+
+    def lock_is_stealable(self):
+        return False
+
+    def lock_info(self):
+        return None

--- a/plone/locking/configure.zcml
+++ b/plone/locking/configure.zcml
@@ -22,4 +22,12 @@
         allowed_attributes="is_locked is_locked_for_current_user lock_is_stealable lock_info"
         />
 
+    <browser:page
+        for="*"
+        name="plone_lock_info"
+        class=".browser.locking.LockingInformationFallback"
+        permission="zope2.View"
+        allowed_attributes="is_locked is_locked_for_current_user lock_is_stealable lock_info"
+        />
+
 </configure>

--- a/plone/locking/tests/test_views.py
+++ b/plone/locking/tests/test_views.py
@@ -1,0 +1,44 @@
+# -*- coding: utf-8 -*-
+from plone.app.testing import setRoles
+from plone.app.testing import TEST_USER_ID
+from plone.locking.browser.locking import LockingInformation
+from plone.locking.browser.locking import LockingInformationFallback
+from plone.locking.testing import PLONE_LOCKING_INTEGRATION_TESTING
+from plone.dexterity.interfaces import IDexterityFTI
+from zope.component import queryUtility
+
+import unittest
+
+
+class TestLockInfoViewWithoutLocking(unittest.TestCase):
+
+    layer = PLONE_LOCKING_INTEGRATION_TESTING
+
+    view = "@@plone_lock_info"
+
+    def setUp(self):
+        self.app = self.layer["app"]
+        self.portal = self.layer["portal"]
+
+        setRoles(self.portal, TEST_USER_ID, ["Manager", "Site Administrator"])
+
+        self.portal.invokeFactory("News Item", id="news1", title="News Item 1")
+        self.news = self.portal["news1"]
+
+        # Remove plone.locking from Document content type
+        fti = queryUtility(IDexterityFTI, name="Document")
+        behavior_list = [a for a in fti.behaviors if a != "plone.locking"]
+        fti.behaviors = tuple(behavior_list)
+
+        self.portal.invokeFactory("Document", id="doc1", title="Document 1")
+        self.doc = self.portal["doc1"]
+
+    def test_browser_view_available_for_content_with_locking_behavior(self):
+        content = self.news
+        view = content.restrictedTraverse(self.view)
+        self.assertIsInstance(view, LockingInformation)
+
+    def test_browser_view_available_for_content_without_locking_behavior(self):
+        content = self.doc
+        view = content.restrictedTraverse(self.view)
+        self.assertIsInstance(view, LockingInformationFallback)


### PR DESCRIPTION
Register a fallback @@plone_lock_info view to allow objects without plone.locking behavior to be edited.

Fix https://github.com/plone/Products.CMFPlone/issues/3331